### PR TITLE
The issue about the left margin of the commenter's avatar

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -98,6 +98,7 @@
         display: block;
         box-sizing: content-box;
         text-align: center;
+        margin-left: 12px;
         margin-right: 12px;
       }
 


### PR DESCRIPTION
## Adjust the left margin of header icon and set it to 12px.   
![left-margin](https://charjin.top/upload/2019/6/left-margin-0dbf5e93cfef4e069b490d5d28e6de92.png)