### PR TITLE
fix: add missing size parameter for fallback avatar

### DIFF
--- a/src/components/CommentEditor.vue
+++ b/src/components/CommentEditor.vue
@@ -168,7 +168,7 @@ export default {
       const gravatarSource = this.options.gravatar_source || '//cn.gravatar.com/avatar/'
 
       if (!this.comment.email || !isEmail(this.comment.email)) {
-        return `${gravatarSource}?d=${gravatarDefault}`
+        return `${gravatarSource}?s=256&d=${gravatarDefault}`
       }
 
       const gravatarMd5 = md5(this.comment.email)

--- a/src/components/CommentPlaceholder.vue
+++ b/src/components/CommentPlaceholder.vue
@@ -48,7 +48,7 @@ export default {
       const gravatarSource = this.options.gravatar_source || '//cn.gravatar.com/avatar/'
 
       if (!this.comment.email || !isEmail(this.comment.email)) {
-        return `${gravatarSource}?d=${gravatarDefault}`
+        return `${gravatarSource}?s=256&d=${gravatarDefault}`
       }
 
       const gravatarMd5 = md5(this.comment.email)


### PR DESCRIPTION
Maybe a better approach is calculating the avatar size required based on `window. devicePixelRatio`.

The size parameter in normal avatar URL (returned from backend) is also missing. I'll open another PR.